### PR TITLE
Add setting to allow editing the giftable cart price

### DIFF
--- a/admin/Settings.php
+++ b/admin/Settings.php
@@ -104,6 +104,15 @@ class WC_Settings_Gifts extends WC_Settings_Page {
 			),
 
 			array(
+				'title'    => __( 'Cart gift price text', DGFW::TRANSLATION ),
+				'desc'     => __( 'Text of the gift price shown for each gift in the cart', DGFW::TRANSLATION ),
+				'id'       => 'woocommerce_dgfw_cart_gift_price_text',
+				'default'  => __( 'FREE!', DGFW::TRANSLATION ),
+				'type'     => 'text',
+				'desc_tip' =>  true,
+			),
+
+			array(
 				'title'    => __( 'Number of gifts per page on large screens (desktop)', DGFW::TRANSLATION ),
 				'id'       => 'woocommerce_dgfw_carousel_gifts_large',
 				'default'  => 4,

--- a/public/Public.php
+++ b/public/Public.php
@@ -398,7 +398,8 @@ class DGFW_Public extends DGFW {
 	public function gift_cart_price($price, $_product)
 	{
 		if ($this->is_gift($_product)) {
-			return __('FREE!', DGFW::TRANSLATION);
+			$value = WC_Admin_Settings::get_option('woocommerce_dgfw_cart_gift_price_text', __('FREE!', DGFW::TRANSLATION));
+			return __($value, DGFW::TRANSLATION);
 		}
 
 		return $price;


### PR DESCRIPTION
I needed to change the string "FREE!" used by Giftable as the cart price so added it as an option. I've not updated the languages/giftable-for-woocommerce.pot file with the new strings. Hopefully that's trivial for you to do. Feel free to merge. NB. I'm new to submitting pull requests so please bear with me if I've done anything idiotic. :-).